### PR TITLE
Change UI for Project Details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.3)
+    ffi (1.15.3-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
@@ -53,13 +55,22 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc (2.4.0-x64-mingw32)
+      ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2021.1)
+      tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
+    wdm (0.1.1)
     webrick (1.7.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll (~> 4.1.1)
@@ -69,4 +80,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.3
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.3)
-    ffi (1.15.3-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
@@ -55,22 +53,13 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc (2.4.0-x64-mingw32)
-      ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2021.1)
-      tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
-    wdm (0.1.1)
     webrick (1.7.0)
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   jekyll (~> 4.1.1)
@@ -80,4 +69,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.22
+   2.2.3

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -2,3 +2,4 @@
   event: MLH Fellowship Pre Fellowship Project
   date: Summer 2021  - Batch 3.5
   page-name: project
+  project-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -1,19 +1,19 @@
 <h2>Projects</h2>
 <div class="card-container">
-    {% for item in site.data.projects %}
-    {% if item.page-name %}
-    <a href="/projects/{{ item.page-name }}">
-    {% else %}
-    <a>
-    {% endif %}
-      <div class="card">
-        <div class="info">
-          <p class="title">{{ item.title }}</p>
-          <p class="location">{{ item.event }}</p>
-          <p class="dates">{{ item.date }}</p>
-        </div>
-      </div>
-    </a>
-    {% endfor %}
+
+  {% for item in site.data.projects %}
+  {% if item.page-name %}
+  {% else %}
+  {% endif %}
+  <div class="card project">
+    <div class="info">
+      <p class="title">{{ item.title }}</p>
+      <p class="location">{{ item.event }}</p>
+      <p class="dates">{{ item.date }}</p>
+    </div>
+    <div class="content">{{ item.project-description }}<br> 
+      <img class="arrow content" src="https://img.icons8.com/ios-filled/50/ffffff/long-arrow-right.png"  onclick="location.href='/projects/{{ item.page-name }}'"/>
+    </div>
   </div>
-  
+  {% endfor %}
+</div>

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -88,3 +88,24 @@ a {
         width: 100%;
     }
 }
+.project>.content {
+  color: white;
+  display: none;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+}
+.project:hover{
+  background-color: #1C539F;
+}
+.project:hover>.content {
+  display: block;
+}
+
+.project:hover>.info {
+  display: none;
+}
+
+.arrow{
+  float:right;
+}


### PR DESCRIPTION
Solves issue [#4](https://github.com/MLH-Fellowship/pod-3.1.0-portfolio/issues/4) 

Description: On hovering, the project description pops up on the screen and there is an arrow that gives the user the option to move to the detailed site of the project.
This makes the portfolio better from a UI perspective.

## Without hover:
![image](https://user-images.githubusercontent.com/63183513/126546411-5aca133b-d114-4580-8450-7bc63b8155b8.png)
## On hover:
![image](https://user-images.githubusercontent.com/63183513/126546377-5b159876-c679-4432-b148-fc566515ad50.png)
